### PR TITLE
Laravel 6.0 Upgrade

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -14,7 +14,7 @@
     ],
     "require": {
         "php" : "^7.0",
-        "laravel/framework": "^5.3"
+        "laravel/framework": "^5.3|^6.0"
     },
     "autoload": {
         "psr-4": {


### PR DESCRIPTION
Without this update.  Cannot upgrade to Laravel 6 using this package.

- Conclusion: don't install laravel/framework v6.0.0

- rorecek/laravel-ulid v2.0.1 requires laravel/framework ^5.3 -> satisfiable by laravel/framework[5.3.x-dev, 5.4.x-dev, 5.5.x-dev, 5.6.x-dev, 5.7.x-dev, 5.8.x-dev].