### PR TITLE
Set key type to string

### DIFF
--- a/src/HasUlid.php
+++ b/src/HasUlid.php
@@ -25,4 +25,9 @@ trait HasUlid
     {
         return false;
     }
+
+    public function getKeyType()
+    {
+        return 'string';
+    }
 }


### PR DESCRIPTION
Adds the getKeyType function to set the key type to string.

Fixes #5 