### PR TITLE
added uild column option

### DIFF
--- a/src/HasUlid.php
+++ b/src/HasUlid.php
@@ -5,16 +5,18 @@ trait HasUlid
 {
     protected static function bootHasUlid()
     {
-        static::creating(function ($model) {
-            if (! $model->id) {
-                $model->id = \Ulid::generate();
+        $column = property_exists(static::class, 'ulidColumn') ? static::$ulidColumn : 'id';
+
+        static::creating(function ($model) use ($column) {
+            if (! $model->{$column}) {
+                $model->{$column} = Ulid::generate();
             }
         });
 
-        static::saving(function ($model) {
-            $originalUlid = $model->getOriginal('id');
-            if ($originalUlid !== $model->id) {
-                $model->id = $originalUlid;
+        static::saving(function ($model) use ($column) {
+            $originalUlid = $model->getOriginal($column);
+            if ($originalUlid !== $model->{$column}) {
+                $model->{$column} = $originalUlid;
             }
         });
     }


### PR DESCRIPTION
column is referring a static property `$ulidColumn` or by default `id`. User have the option to set the column name for uild, it's rare but sometimes we might choose to keep the id as auto incremented col but want uild as a standalone unique column.

in models user can optionally set the column name :-

```php
use HasUlid;

public static $ulidColumn = 'id';
```