### PR TITLE
Add ulid macro to Blueprint class

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,5 @@ docs
 vendor
 tests/temp
 composer.lock
+
+.idea/

--- a/README.md
+++ b/README.md
@@ -71,14 +71,14 @@ You must install the service provider and facade:
 When using the migration you should change $table->increments('id') to:
 
 ``` php
-$table->char('id', 26)->primary();
+$table->ulid()->primary(); // creates 'id' column by default
 ```
 
 > Simply, the schema seems something like this.
 
 ``` php
 Schema::create('items', function (Blueprint $table) {
-  $table->char('id', 26)->primary();
+  $table->ulid()->primary(); // creates 'id' column by default
   ....
   ....
   $table->timestamps();
@@ -89,10 +89,10 @@ If the related model is using an ULID, the column type should reflect that also.
 
 ``` php
 Schema::create('items', function (Blueprint $table) {
-  $table->char('id', 26)->primary();
+  $table->ulid()->primary();
   ....
   // related model that uses ULID
-  $table->char('category_id', 26);
+  $table->ulid('category_id');
   $table->foreign('category_id')->references('id')->on('categories');
   ....
   $table->timestamps();

--- a/src/UlidServiceProvider.php
+++ b/src/UlidServiceProvider.php
@@ -3,6 +3,7 @@
 namespace Rorecek\Ulid;
 
 use Illuminate\Support\ServiceProvider;
+use Illuminate\Database\Schema\Blueprint;
 
 class UlidServiceProvider extends ServiceProvider
 {
@@ -13,7 +14,9 @@ class UlidServiceProvider extends ServiceProvider
      */
     public function boot()
     {
-        //
+        Blueprint::macro('ulid', function ($column = 'id') {
+            return $this->char($column, 26)->unique();
+        });
     }
 
     /**


### PR DESCRIPTION
In migration just write ```$table->ulid('column_name')``` instead of ```$table->char('column_name', 26)```, so devs are not forced to remember that ulid is 26 characters long char type. 

This PR is backward compatible, means ```$table->char('id', 26)``` will still work

**To consider** - as ULID is mentioned to be used as primary key, maybe it can be specified in macro instead of ```->unique()```